### PR TITLE
fix: Handle date clearing and correct log date display

### DIFF
--- a/index.html
+++ b/index.html
@@ -1711,6 +1711,9 @@
                 const oldDate = currentOwner.next_follow_up;
                 const ownerIndex = allOwners.findIndex(o => o.id === currentOwner.id);
 
+                // If value is an empty string, it means the date was cleared. Use null for the database.
+                const valueForDb = value === '' ? null : value;
+
                 // 1. Optimistically update local data
                 currentOwner.next_follow_up = value;
                 if (ownerIndex !== -1) allOwners[ownerIndex].next_follow_up = value;
@@ -1722,7 +1725,7 @@
                     // 3. Update database
                     const { data, error } = await supabase
                         .from('owners')
-                        .update({ next_follow_up: value })
+                        .update({ next_follow_up: valueForDb })
                         .eq('id', currentOwner.id)
                         .select()
                         .single();
@@ -1808,7 +1811,9 @@
         function formatDate(dateString) {
             if (!dateString) return 'No date';
             const date = new Date(dateString);
-            return date.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+            // Use timeZone: 'UTC' to prevent the date from being shifted to the previous day
+            // due to the user's local timezone.
+            return date.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric', timeZone: 'UTC' });
         }
 
         // Delete Property


### PR DESCRIPTION
This commit addresses two bugs related to date handling:

1.  **Clear Next Follow-Up Date:** The `updateOwner` function now correctly sends a `null` value to the database when the "Next Follow-Up" date is cleared in the UI. This prevents a database error that occurred when sending an empty string.

2.  **Call Log Date Offset:** The `formatDate` function has been updated to use the UTC timezone when formatting dates. This resolves an issue where communication log dates would sometimes display as one day earlier than intended due to the user's local timezone.